### PR TITLE
R2R control scripts can be called standalone or from ragctl.py

### DIFF
--- a/src/orchestration/R2R/clean.sh
+++ b/src/orchestration/R2R/clean.sh
@@ -3,29 +3,81 @@
 # Revert the directory to git-only files
 
 set -euo pipefail
-source "./common_config.sh"
+
+# Get the absolute directory of this script
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Change to the script directory to ensure all relative paths work
+cd "$SCRIPT_DIR"
+
+# Source common configuration
+source "$SCRIPT_DIR/common_config.sh"
+
 trap 'log "❌ An unexpected error occurred."' ERR
 
+log "🧹 Cleaning up R2R project files..."
+log "📍 Working in directory: $SCRIPT_DIR"
+
 log "🧹 Removing R2R upstream configuration files..."
-rm -rf "$SUBDIR"
+if [[ -d "$SUBDIR" ]]; then
+    rm -rf "$SUBDIR"
+    log "✅ Removed $SUBDIR directory"
+else
+    log "ℹ️  $SUBDIR directory not found (already clean)"
+fi
 
 log "🧹 Removing test file..."
-rm -f "$TEST_FILE"
+if [[ -f "$TEST_FILE" ]]; then
+    rm -f "$TEST_FILE"
+    log "✅ Removed $TEST_FILE"
+else
+    log "ℹ️  $TEST_FILE not found (already clean)"
+fi
 
 log "🧹 Removing any Python virtual environment..."
-rm -rf "$VENV_DIR"
+if [[ -d "$VENV_DIR" ]]; then
+    rm -rf "$VENV_DIR"
+    log "✅ Removed virtual environment at $VENV_DIR"
+else
+    log "ℹ️  Virtual environment not found (already clean)"
+fi
 
-log "🧹 Removing Python cache..."
-rm -rf "$SMOKE_DIR"/__pycache__
-rm -rf "$SMOKE_DIR"/.ropeproject
-rm -rf .ropeproject
+log "🧹 Removing Python cache files..."
+# Remove cache in smoke-tests directory if it exists
+if [[ -d "$SMOKE_DIR" ]]; then
+    rm -rf "$SMOKE_DIR"/__pycache__
+    rm -rf "$SMOKE_DIR"/.ropeproject
+    log "✅ Cleaned Python cache in smoke-tests directory"
+else
+    log "ℹ️  Smoke-tests directory not found"
+fi
+
+# Remove ropeproject in the script directory (use absolute path)
+if [[ -d "$SCRIPT_DIR/.ropeproject" ]]; then
+    rm -rf "$SCRIPT_DIR/.ropeproject"
+    log "✅ Removed .ropeproject in script directory"
+else
+    log "ℹ️  .ropeproject not found in script directory"
+fi
 
 # Prune dangling images, stopped containers, unused networks
-log "🧹 Cleaning up dangling Docker images..."
-docker image prune -f
+log "🧹 Cleaning up Docker resources..."
 
-log "🧹 Cleaning up stopped containers..."
-docker container prune -f
+# Check if Docker is available before attempting cleanup
+if command -v docker &> /dev/null && docker info &> /dev/null; then
+    log "🧹 Cleaning up dangling Docker images..."
+    docker image prune -f
 
-log "🧹 Cleaning up unused networks..."
-docker network prune -f
+    log "🧹 Cleaning up stopped containers..."
+    docker container prune -f
+
+    log "🧹 Cleaning up unused networks..."
+    docker network prune -f
+
+    log "✅ Docker cleanup completed"
+else
+    log "⚠️  Docker not available or not running - skipping Docker cleanup"
+fi
+
+log "🎉 Cleanup completed successfully!"
+log "📍 Script directory: $SCRIPT_DIR"

--- a/src/orchestration/R2R/common_config.sh
+++ b/src/orchestration/R2R/common_config.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # Common configuration for R2R orchestration scripts
 
+# Get the directory of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 # Logging function used by all scripts
 log() { echo -e "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
 
 # Project settings
 PROJECT_NAME="myrag"
 SUBDIR="docker"
-COMPOSE_FILE="./docker/compose.full.yaml"
-OVERRIDE_FILE="./compose.override.yaml"
-KEYS_FILE="../../../../credentials/API_KEYS"
-VENV_DIR="./venv"
+COMPOSE_FILE="${SCRIPT_DIR}/docker/compose.full.yaml"
+OVERRIDE_FILE="${SCRIPT_DIR}/compose.override.yaml"
+KEYS_FILE="${SCRIPT_DIR}/../../../../credentials/API_KEYS"
+VENV_DIR="${SCRIPT_DIR}/venv"
 
 # Docker settings
 DOCKER_IMAGE="docker.io/sciphiai/r2r:latest"
@@ -25,7 +28,7 @@ HEALTH_CHECK_TIMEOUT=10
 DOCKER_STOP_TIMEOUT=15
 
 # Test settings
-SMOKE_DIR="./smoke-tests"
+SMOKE_DIR="${SCRIPT_DIR}/smoke-tests"
 TEST_FILE="test.txt"
 TEST_CONTENT="QuetzalX is a person that works at CIRED."
 TEST_QUERY="Who is QuetzalX?"

--- a/src/orchestration/R2R/install.sh
+++ b/src/orchestration/R2R/install.sh
@@ -7,7 +7,11 @@
 # 4. Pull R2R docker images
 
 set -euo pipefail
-source "./common_config.sh"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+source "$SCRIPT_DIR/common_config.sh"
+
 trap 'log "❌ An unexpected error occurred."' ERR
 
 #
@@ -54,7 +58,12 @@ cd "$TEMP_DIR"
 git sparse-checkout init --cone
 git sparse-checkout set "$SUBDIR"
 git checkout
-cd -
+cd "$SCRIPT_DIR"
+
+# Remove existing target directory if it exists
+if [[ -d "./$TARGET_DIR" ]]; then
+  rm -rf "./$TARGET_DIR"
+fi
 mv "$TEMP_DIR/$SUBDIR" "./$TARGET_DIR"
 rm -rf "$TEMP_DIR"
 log "✅ Successfully fetched $SUBDIR from $REPO_URL."
@@ -102,3 +111,6 @@ if [ ! -d "$VENV_DIR" ]; then
 else
     log "✅ Virtual environment already exists."
 fi
+
+log "🎉 Installation completed successfully!"
+log "📍 Script directory: $SCRIPT_DIR"

--- a/src/orchestration/R2R/start.sh
+++ b/src/orchestration/R2R/start.sh
@@ -9,7 +9,9 @@
 #  MISTRAL_API_KEY=...
 
 set -euo pipefail
-source "./common_config.sh"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+source "$SCRIPT_DIR/common_config.sh"
 trap 'log "❌ An unexpected error occurred."' ERR
 
 # Validate we have docker

--- a/src/orchestration/R2R/stop.sh
+++ b/src/orchestration/R2R/stop.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-source "./common_config.sh"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+source "$SCRIPT_DIR/common_config.sh"
 trap 'log "❌ An unexpected error occurred."' ERR
 
 # Require root, we may have to restart dockerd and kill processes

--- a/src/orchestration/R2R/validate.sh
+++ b/src/orchestration/R2R/validate.sh
@@ -9,7 +9,9 @@
 # 3.3 TODO: Ingest and query scientific papers as PDFs
 
 set -euo pipefail
-source "./common_config.sh"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+source "$SCRIPT_DIR/common_config.sh"
 trap 'log "❌ An unexpected error occurred."' ERR
 
 

--- a/src/orchestration/ragctl.py
+++ b/src/orchestration/ragctl.py
@@ -39,11 +39,9 @@ BASE_DIR = Path(__file__).resolve().parent
 # Configure logging for operational/debug logs
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-    handlers=[
-        logging.StreamHandler(sys.stderr)
-    ]
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[logging.StreamHandler(sys.stderr)],
 )
 logger = logging.getLogger(__name__)
 
@@ -116,7 +114,9 @@ def load_env(engine: str, env: str) -> None:
     """
     env_file = BASE_DIR / engine / f"env_{env}.cfg"
     if not env_file.is_file():
-        logger.warning('Environment file %s not found for engine "%s".', env_file, engine)
+        logger.warning(
+            'Environment file %s not found for engine "%s".', env_file, engine
+        )
         return
 
     logger.info("Loading environment variables from %s", env_file)
@@ -126,7 +126,7 @@ def load_env(engine: str, env: str) -> None:
         if line and not line.startswith("#"):
             if "=" not in line:
                 raise EnvironmentFileError(
-                    "Invalid line %d in %s: %s" % (line_number, env_file, line)
+                    f"Invalid line {line_number} in {env_file}: {line}"
                 )
             key, value = line.split("=", 1)
             key = key.strip()
@@ -134,7 +134,7 @@ def load_env(engine: str, env: str) -> None:
             if key in os.environ:
                 logger.warning(
                     "Overriding existing environment variable: %s (expected if reloading configs)",
-                    key
+                    key,
                 )
             os.environ[key] = value
 
@@ -158,7 +158,7 @@ def get_engine_dir(engine: str) -> Path:
     """
     engine_dir = BASE_DIR / engine
     if not engine_dir.is_dir():
-        raise EngineError('Engine "%s" not found under %s/' % (engine, BASE_DIR))
+        raise EngineError(f'Engine "{engine}" not found under {BASE_DIR}/')
     return engine_dir
 
 
@@ -186,9 +186,8 @@ def run_script(engine: str, command: str, env: str, debug: bool) -> None:
     if not script_path.is_file():
         available_scripts = [f.name for f in engine_dir.glob("*.sh")]
         raise EngineError(
-            'Script "%s" not found for engine "%s". '
-            "Available scripts: %s"
-            % (script_name, engine, available_scripts)
+            f'Script "{script_name}" not found for engine "{engine}". '
+            f"Available scripts: {available_scripts}"
         )
 
     load_env(engine, env)
@@ -203,9 +202,8 @@ def run_script(engine: str, command: str, env: str, debug: bool) -> None:
             logger.debug("STDERR:\n%s", result.stderr)
     except subprocess.CalledProcessError as e:
         raise ScriptExecutionError(
-            'Script "%s" failed with exit code %d\n'
-            "STDOUT:\n%s\nSTDERR:\n%s"
-            % (script_name, e.returncode, e.stdout, e.stderr)
+            f'Script "{script_name}" failed with exit code {e.returncode}\n'
+            f"STDOUT:\n{e.stdout}\nSTDERR:\n{e.stderr}"
         )
 
 
@@ -290,7 +288,7 @@ def main() -> None:
         if args.debug or os.environ.get("RAGCTL_DEBUG") == "1":
             logging.getLogger().setLevel(logging.DEBUG)
             logger.debug("Debug logging enabled")
-        
+
         if args.list_commands:
             if args.engine:
                 cmds = discover_commands(args.engine)
@@ -304,7 +302,7 @@ def main() -> None:
             sys.exit(1)
 
         if args.engine not in available_engines:
-            raise EngineError("Unknown engine: %s" % args.engine)
+            raise EngineError(f"Unknown engine: {args.engine}")
 
         run_script(args.engine, args.command, args.env, args.debug)
 


### PR DESCRIPTION
* source common_config.sh from script dir, not current dir (don't assume it is called from its dir)
* cd to script dir (just in case)
* More verbose cleaning
* Idempotency: install delete docker before reinstalling over it, if necessary 
* ragctl.py properly log instead of always printing, honors debug level control
* create env_dev.cfg -- for now empty. To be used by common_config.sh