### PR TITLE
chore: simplify docker/ and docker/ops/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/docker/config.upstream/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ This project's goal is to implement a chatbot with CIRED publications.
 
 Project's secret keys and passwords.
 
-- Contents not versionned on GitHub because secret.
-- Contents not synced by Nextcloud.
-- Developer should populate their own local copy.
-- For deployment, transfer keys separately
+- Contents not versionned on GitHub, not synced by Nextcloud.
+- Must be transferred securely to production.
+- Templates are `src/docker/ops/config.upstream/env/*.env`, which is pulled from upstream with `src/docker/ops/install.sh`.
+- Then edit files with their own local API_KEYs.
 
 ### `data/`
 raw PDFs, extracted text, metadata, summaries, chunks, vector indexes...

--- a/src/docker/compose.yaml
+++ b/src/docker/compose.yaml
@@ -2,30 +2,30 @@
 
 volumes:
   hatchet_certs:
-    name: ${PROJECT_NAME}_hatchet_certs
+    name: cidir2r_hatchet_certs
   hatchet_config:
-    name: ${PROJECT_NAME}_hatchet_config
+    name: cidir2r_hatchet_config
   hatchet_api_key:
-    name: ${PROJECT_NAME}_hatchet_api_key
+    name: cidir2r_hatchet_api_key
   hatchet_rabbitmq_data:
-    name: ${PROJECT_NAME}_hatchet_rabbitmq_data
+    name: cidir2r_hatchet_rabbitmq_data
   hatchet_rabbitmq_conf:
-    name: ${PROJECT_NAME}_hatchet_rabbitmq_conf
+    name: cidir2r_hatchet_rabbitmq_conf
   hatchet_postgres_data:
-    name: ${PROJECT_NAME}_hatchet_postgres_data
+    name: cidir2r_hatchet_postgres_data
   minio_data:
-    name: ${PROJECT_NAME}_minio_data
+    name: cidir2r_minio_data
   postgres_data:
-    name: ${PROJECT_NAME}_postgres_data
+    name: cidir2r_postgres_data
 
 # Changes:
 # - Use env_files from credentials/ out of repo, they are full of secrets
 # - Fully define paths to images, for security
+# - Postgres included by default, no need to specify profile postgres
 
 services:
   postgres:
     image: docker.io/pgvector/pgvector:pg16
-    profiles: [postgres]
     env_file:
       - ../../credentials/postgres-cidi.env
     volumes:
@@ -42,6 +42,7 @@ services:
       postgres
       -c max_connections=1024
 
+  # Not used by default
   minio:
     image: docker.io/minio/minio
     profiles: [minio]

--- a/src/docker/ops/common_config.sh
+++ b/src/docker/ops/common_config.sh
@@ -38,7 +38,6 @@ docker_compose_cmd() {
     local cmd=(
         docker compose
         --project-name "$PROJECT_NAME"
-        --profile postgres
     )
 
     # Add any passed arguments

--- a/src/docker/ops/common_config.sh
+++ b/src/docker/ops/common_config.sh
@@ -59,6 +59,33 @@ validate_dir() {
     return 0
 }
 
+# Vérifie que Docker est installé et que le démon tourne
+ensure_docker() {
+    local smoke_test=false
+    if [[ "${1:-}" == "--smoke-test" ]]; then
+        smoke_test=true
+    fi
+
+    if ! command -v docker &> /dev/null; then
+        log -e "❌ Docker introuvable. Veuillez installer Docker avant de continuer."
+        exit 1
+    fi
+
+    if ! docker info &> /dev/null; then
+        log -e "❌ Docker installé mais inopérant (daemon arrêté ou problème de permissions)."
+        exit 1
+    fi
+
+    if $smoke_test; then
+        log "🚀 Test smoke: exécution de hello-world"
+        if ! docker run --rm hello-world &> /dev/null; then
+            log -e "❌ Test smoke 'hello-world' a échoué."
+            exit 1
+        fi
+        log "✅ Test smoke 'hello-world' réussi."
+    fi
+}
+
 validate_file() {
     local file="$1"
     if [ ! -f "$file" ]; then

--- a/src/docker/ops/common_config.sh
+++ b/src/docker/ops/common_config.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # --- Project Configuration ---
-export PROJECT_NAME="cidir2r"  # Used as prefix for Docker resources
+export COMPOSE_PROJECT_NAME="cidir2r"  # Used as prefix for Docker resources
 export PROJECT_DESCRIPTION="CIRED R2R Deployment"
 CONFIG_UPSTREAM_DIR="${BASE_DIR}/config.upstream"
 COMPOSE_FILE="${BASE_DIR}/compose.yaml"
@@ -35,10 +35,7 @@ docker_compose_cmd() {
         return 1
     fi
 
-    local cmd=(
-        docker compose
-        --project-name "$PROJECT_NAME"
-    )
+    local cmd=(docker compose -p "$COMPOSE_PROJECT_NAME")
 
     # Add any passed arguments
     cmd+=("$@")
@@ -98,7 +95,7 @@ validate_file() {
 validate_config_files() {
     validate_file "$COMPOSE_FILE" || exit 1
     validate_file "$SECRETS_FILE" || exit 1
-    log "📦 Project: $PROJECT_NAME"
+    log "📦 Project: $COMPOSE_PROJECT_NAME"
     log "🔧 Compose file: $COMPOSE_FILE"
     log "🔑 Secrets env file: $SECRETS_FILE"
 }

--- a/src/docker/ops/down.sh
+++ b/src/docker/ops/down.sh
@@ -54,7 +54,7 @@
 #   Use with caution in production environments.
 #
 # DEPENDENCIES:
-#   - common_config.sh (must define PROJECT_NAME, COMPOSE_FILE)
+#   - common_config.sh (must define COMPOSE_PROJECT_NAME, COMPOSE_FILE)
 #   - systemctl (for Docker daemon restart)
 #   - Standard Unix tools: ps, grep, awk, kill
 #
@@ -138,7 +138,7 @@ check_docker_access
 
 log "1) Attempting graceful shutdown: docker compose down (timeout ${DOWN_TIMEOUT}s)…"
 # Note: timeout disallows using function. So inlining the docker_compose_cmd() from common_config.sh
-if timeout "${DOWN_TIMEOUT}s" docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE" down; then
+if timeout "${DOWN_TIMEOUT}s" docker compose -p "$COMPOSE_PROJECT_NAME" down; then
   log "✅ Compose down completed within ${DOWN_TIMEOUT}s."
 else
   log "⚠️  Compose down did NOT complete in ${DOWN_TIMEOUT}s."
@@ -147,7 +147,7 @@ fi
 log "Gathering still-running containers (timeout ${GATHER_TIMEOUT}s)…"
 CONTAINERS_RAW=$(timeout "${GATHER_TIMEOUT}s" \
     docker ps \
-      --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+      --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" \
       --filter status=running \
       --format '{{.ID}}' 2>/dev/null || true)
 

--- a/src/docker/ops/install.sh
+++ b/src/docker/ops/install.sh
@@ -44,7 +44,7 @@ if ! command -v uv &> /dev/null; then
 fi
 
 #
-# 2. Clone the R2R repository and extract only the docker subdirectory
+# 2. Pulling the docker/ subdir of the R2R repository
 #
 REPO_URL="https://github.com/SciPhi-AI/R2R.git"
 SOURCE_DIR="docker"
@@ -75,7 +75,7 @@ validate_config_files
 # 3. Pull R2R images
 #
 log "📥 Pulling Docker images..."
-docker compose -f "$COMPOSE_FILE" -f "$OVERRIDE_FILE" pull
+docker compose pull
 
 log "✅ Images pulled successfully."
 

--- a/src/docker/ops/install.sh
+++ b/src/docker/ops/install.sh
@@ -10,7 +10,6 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SCRIPT_DIR"
 
 source "$SCRIPT_DIR/common_config.sh"
-ensure_docker --smoke-test
 
 trap 'log "❌ An unexpected error occurred."' ERR
 
@@ -19,8 +18,12 @@ trap 'log "❌ An unexpected error occurred."' ERR
 #
 log "🔍 Checking required dependencies..."
 
+# Verify configuration files exist
+validate_config_files
 
-# Display Docker version
+# Verify Docker runs, display version
+ensure_docker --smoke-test
+
 log "🐳 Docker version:"
 docker --version
 
@@ -55,9 +58,6 @@ fi
 mv "$TEMP_DIR/$SOURCE_DIR" "$TARGET_DIR"
 rm -rf "$TEMP_DIR"
 log "✅ Successfully fetched $SOURCE_DIR from $REPO_URL into $TARGET_DIR."
-
-# Verify configuration files exist
-validate_config_files
 
 #
 # 3. Pull R2R images

--- a/src/docker/ops/install.sh
+++ b/src/docker/ops/install.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SCRIPT_DIR"
 
 source "$SCRIPT_DIR/common_config.sh"
+ensure_docker --smoke-test
 
 trap 'log "❌ An unexpected error occurred."' ERR
 

--- a/src/docker/ops/install.sh
+++ b/src/docker/ops/install.sh
@@ -19,19 +19,6 @@ trap 'log "❌ An unexpected error occurred."' ERR
 #
 log "🔍 Checking required dependencies..."
 
-# Check for Docker
-if ! command -v docker &> /dev/null; then
-  log "❌ Error: Docker is not installed. Please install Docker first."
-  exit 1
-fi
-
-# Run a test container to validate Docker functionality
-log "🚀 Testing Docker installation..."
-if ! docker run --rm hello-world &> /dev/null; then
-  log "❌ Error: Docker is installed but not working correctly."
-  exit 1
-fi
-log "✅ Docker test successful."
 
 # Display Docker version
 log "🐳 Docker version:"

--- a/src/docker/ops/restore.sh
+++ b/src/docker/ops/restore.sh
@@ -118,10 +118,10 @@ cleanup_backup_volumes() {
 
 # Now safe to stop containers
 # Check and stop running containers
-running_containers=$(docker ps --format '{{.Names}}' | grep -E "${PROJECT_NAME}" || true)
+running_containers=$(docker ps --format '{{.Names}}' | grep -E "${COMPOSE_PROJECT_NAME}" || true)
 
 if [ -n "$running_containers" ]; then
-    log -w "Stopping running containers for $PROJECT_NAME..."
+    log -w "Stopping running containers for $COMPOSE_PROJECT_NAME..."
     docker_compose_cmd stop
     sleep 5
     should_restart=true
@@ -146,7 +146,7 @@ fi
 for archive in $volume_archives; do
     # Get volume name from archive filename
     volume_name=$(basename "$archive" .tar)
-    full_volume_name="${PROJECT_NAME}_${volume_name}"
+    full_volume_name="${COMPOSE_PROJECT_NAME}_${volume_name}"
 
     log "Restoring volume: $full_volume_name"
 

--- a/src/docker/ops/snapshot.sh
+++ b/src/docker/ops/snapshot.sh
@@ -13,13 +13,13 @@ BACKUP_DIR="${ARCHIVES_DIR}/${SNAPSHOT_NAME}"
 mkdir -p "$BACKUP_DIR"
 
 log "Checking for running containers..."
-running_containers=$(docker ps --format '{{.Names}}' | grep -E "${PROJECT_NAME}" || true)
+running_containers=$(docker ps --format '{{.Names}}' | grep -E "${COMPOSE_PROJECT_NAME}" || true)
 
 if [ -n "$running_containers" ]; then
-    log -w "Found running containers for $PROJECT_NAME, stopping them temporarily..."
+    log -w "Found running containers for $COMPOSE_PROJECT_NAME, stopping them temporarily..."
 
     # Store container IDs and their start commands
-    container_info=$(docker ps --filter "name=${PROJECT_NAME}" --format '{{.ID}} {{.Command}}')
+    container_info=$(docker ps --filter "name=${COMPOSE_PROJECT_NAME}" --format '{{.ID}} {{.Command}}')
 
     # Stop containers
     docker_compose_cmd stop
@@ -28,7 +28,7 @@ if [ -n "$running_containers" ]; then
     sleep 5
 
     # Verify they're stopped
-    if docker ps --format '{{.Names}}' | grep -E "${PROJECT_NAME}" | grep -q .; then
+    if docker ps --format '{{.Names}}' | grep -E "${COMPOSE_PROJECT_NAME}" | grep -q .; then
         log -e "Failed to stop containers, aborting snapshot"
         exit 1
     fi
@@ -39,13 +39,13 @@ else
     should_restart=false
 fi
 
-log "📦 Creating snapshots for all volumes in project $PROJECT_NAME"
+log "📦 Creating snapshots for all volumes in project $COMPOSE_PROJECT_NAME"
 
 # Get all volumes for this project
-project_volumes=$(docker volume ls --filter "name=${PROJECT_NAME}" -q)
+project_volumes=$(docker volume ls --filter "name=${COMPOSE_PROJECT_NAME}" -q)
 
 if [ -z "$project_volumes" ]; then
-    log -e "No volumes found for project $PROJECT_NAME"
+    log -e "No volumes found for project $COMPOSE_PROJECT_NAME"
     exit 2
 fi
 
@@ -54,7 +54,7 @@ for volume in $project_volumes; do
     log "Backing up volume: $volume"
 
     # Extract the short name (without project prefix)
-    volume_short_name=$(echo "$volume" | sed "s/${PROJECT_NAME}_//")
+    volume_short_name=$(echo "$volume" | sed "s/${COMPOSE_PROJECT_NAME}_//")
 
     # Create tar of the volume
     if docker run --rm \

--- a/src/docker/ops/up.sh
+++ b/src/docker/ops/up.sh
@@ -10,29 +10,6 @@ source "$SCRIPT_DIR/common_config.sh"
 ensure_docker
 trap 'log "❌ An unexpected error occurred."' ERR
 
-# Validate we have docker
-if ! command -v docker &> /dev/null; then
-  log "❌ Error: Docker is not installed or not in PATH."
-  log "    To install Docker from Docker's official repository:"
-  log "    # Add Docker's official GPG key"
-  log "    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg"
-  log "    # Add Docker repository"
-  log "    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable' | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null"
-  log "    # Install Docker Engine"
-  log "    sudo apt update && sudo apt install docker-ce docker-ce-cli containerd.io docker-compose-plugin"
-  log "    # Or use the convenience script: curl -fsSL https://get.docker.com | sh"
-  log "    For other systems: https://docs.docker.com/get-docker/"
-  exit 1
-fi
-
-if ! docker info > /dev/null 2>&1; then
-  log "Error: Docker is installed but not working correctly."
-  log "    Possible causes:"
-  log "    - Docker daemon is not running (try: sudo systemctl start docker)"
-  log "    - Permission issue (try: sudo usermod -aG docker $USER, then log out/in)"
-  log "    - Docker socket permissions"
-  exit 1
-fi
 
 # Verify configuration files exist
 validate_config_files

--- a/src/docker/ops/up.sh
+++ b/src/docker/ops/up.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SCRIPT_DIR"
 source "$SCRIPT_DIR/common_config.sh"
+ensure_docker
 trap 'log "❌ An unexpected error occurred."' ERR
 
 # Validate we have docker

--- a/src/docker/ops/up.sh
+++ b/src/docker/ops/up.sh
@@ -7,12 +7,10 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SCRIPT_DIR"
 source "$SCRIPT_DIR/common_config.sh"
-ensure_docker
 trap 'log "❌ An unexpected error occurred."' ERR
 
-
-# Verify configuration files exist
 validate_config_files
+ensure_docker
 
 log "🚀 Starting services..."
 docker_compose_cmd up -d

--- a/src/docker/ops/validate.sh
+++ b/src/docker/ops/validate.sh
@@ -77,7 +77,7 @@ check_r2r_health() {
 
 # Check for API keys in the R2R container
 check_api_keys() {
-    local container_name="${PROJECT_NAME}-r2r-1"
+    local container_name="${COMPOSE_PROJECT_NAME}-r2r-1"
     log "🔍 Checking for API keys in container '$container_name'..."
 
     if docker ps --format '{{.Names}}' | grep -q "^${container_name}$"; then
@@ -95,7 +95,7 @@ check_api_keys() {
 
 check_container_logs() {
     local container_name="$1"
-    local full_container_name="${PROJECT_NAME}-${container_name}-1"
+    local full_container_name="${COMPOSE_PROJECT_NAME}-${container_name}-1"
 
     log "🔍 Checking logs for container '$full_container_name'..."
 


### PR DESCRIPTION
Use docker compose conventions:
- No need to specify compose.yaml filename
- Drop postgres container profile option to include it in the stack by default
- PROJECT_NAME should be COMPOSE_PROJECT_NAME.
- Simplify up.sh and install.sh by moving shared docker checking code to common_utils.sh