### PR TITLE
Remove non-functional web search option from settings

### DIFF
--- a/src/frontend/config-ui.js
+++ b/src/frontend/config-ui.js
@@ -90,12 +90,12 @@ document.getElementById("config-panel").innerHTML = `
       </label>
     </div>
 
-    <div class="form-group">
+    <!--div class="form-group">
       <label class="checkbox-label">
         <input type="checkbox" id="include-web-search" class="checkbox-input"  disabled>
         <span class="web-search-text"><strong>Recherche Web</strong> – Inclure les résultats web (0.1 cent par question)</span>
       </label>
-    </div>
+    </div-->
 
     </main> <!-- id="settings-container"-->
 `


### PR DESCRIPTION
Problem Description:

In the current `ciredsettings`, the web search option is non-functional — clicking it does not trigger any action or return results. This causes confusion and degrades user experience.

After evaluating the issue, the web search option from the settings is removed  to avoid misleading users and to keep the interface clean and functional.

This pull request removes the web search option from the settings and related UI components.

Please review and provide feedback.
