### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/src/analytics/monitor.py
+++ b/src/analytics/monitor.py
@@ -80,11 +80,10 @@ async def monitor_event(event: MonitorEvent) -> dict[str, str]:
     os.makedirs(dir_path, exist_ok=True)
     # Now save the event as a JSON file
     filename = f"{safe_session}-{safe_timestamp}-{safe_type}.json"
-    file_path = os.path.normpath(os.path.join(dir_path, filename))
-    abs_dir_path = os.path.abspath(dir_path)
-    abs_file_path = os.path.abspath(os.path.normpath(file_path))
-    # Ensure the normalized file_path is within the intended directory
-    if not abs_file_path.startswith(abs_dir_path + os.sep):
+    file_path = os.path.realpath(os.path.join(dir_path, filename))
+    abs_dir_path = os.path.realpath(dir_path)
+    # Ensure the resolved file_path is strictly within the intended directory
+    if os.path.commonpath([abs_dir_path, file_path]) != abs_dir_path:
         raise ValueError("Invalid file path: potential path traversal detected")
     with open(file_path, "w", encoding="utf-8") as f:
         json.dump(event.model_dump(), f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
Potential fix for [https://github.com/MinhHaDuong/cired.digital/security/code-scanning/11](https://github.com/MinhHaDuong/cired.digital/security/code-scanning/11)

To address the identified issue:
1. Normalize the `file_path` and `dir_path` using `os.path.realpath` instead of `os.path.abspath`. This resolves symbolic links and ensures that the paths are canonical.
2. Enhance the validation check to ensure that `file_path` resides strictly within the intended directory structure.
3. Use `os.path.commonpath` to compare the base directory and the final file path, which is a more robust way to verify containment.

These changes will ensure that the constructed `file_path` is safe and cannot be manipulated to escape the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
