### PR TITLE
docs(deploy): document secret/API-key rotation procedure

### DIFF
--- a/deploy/HOWTO-deploy.md
+++ b/deploy/HOWTO-deploy.md
@@ -49,6 +49,28 @@ this will do a remote git pull, restart and validate.
    ./validate.sh --remote
    ```
 
+## Rotating secrets and API keys
+
+Edit the relevant file in `secrets/env/` (e.g. `r2r-full.env`), push it, then
+**recreate** the affected container:
+
+```bash
+./push_secrets.sh
+./up.sh --remote          # recreates containers, re-reading env_file
+```
+
+- Write each secret as a real assignment: `OPENAI_API_KEY=sk-proj-...`. A bare
+  value with no `VAR=` prefix leaves the variable undefined.
+- **`docker restart` does NOT pick up a changed key.** It bounces the process
+  with the environment baked in at container *creation*. Only `up.sh --remote`
+  (i.e. `docker compose up -d --force-recreate <service>`) re-reads `env_file`.
+- Verify the swap with a **novel** query, not a repeated one: R2R caches query
+  embeddings, so a repeated query can return 200 from cache and hide a bad key.
+  Confirm the loaded key without printing it:
+  ```bash
+  docker exec cidir2r-r2r-1 sh -c 'printf %s "$OPENAI_API_KEY" | tail -c 4'
+  ```
+
 ## Backuping and updating the corpus Data
 
 1. Create a snapshot locally:


### PR DESCRIPTION
## Context
During the 2026-06-22 outage recovery, rotating `OPENAI_API_KEY` took ~1h because `docker restart` was used to reload the key. `docker restart` re-reads nothing — it bounces the process with the environment baked in at container creation, so the old (revoked) key kept being served and every query 500'd with a 401. Only `docker compose up` (via `up.sh --remote`) re-reads `env_file`.

## Change
Adds a **Rotating secrets and API keys** section to `deploy/HOWTO-deploy.md` documenting the correct procedure and three traps from the incident:
- `docker restart` does not reload `env_file` — use `up.sh --remote`.
- The key must be a real `VAR=value` assignment (a bare value leaves it undefined).
- Verify with a *novel* query — R2R caches query embeddings, so a repeated query can pass on cache and hide a bad key.

Doc-only; no code paths touched.

Relates to #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)