### PR TITLE
chore: prefer project-local uv over global pipx for ruff/pytest

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- [ ] Remove global pipx installs of ruff and pytest (`pipx uninstall ruff pytest`).
+  They shadow the project-local versions managed by uv and can cause version drift.
+  Use `uv run ruff` and `uv run pytest` instead.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,7 @@
 # TODO
 
-- [ ] Remove global pipx installs of ruff and pytest (`pipx uninstall ruff pytest`).
+- [ ] Remove global pipx installs of ruff, pytest, mypy, and pre-commit
+  (`pipx uninstall ruff pytest mypy pre-commit`).
   They shadow the project-local versions managed by uv and can cause version drift.
-  Use `uv run ruff` and `uv run pytest` instead.
+  Run each tool via `uv run <tool>` (e.g. `uv run ruff`, `uv run pytest`,
+  `uv run mypy`, `uv run pre-commit`) instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,8 @@ dependencies = [
   "polars>=1.0.0",
 ]
 
-# Note: Ubuntu distro version of `ruff`, `pytest`, `mypy` tend to be old.
-# Rather install the latest version in `.local/bin/` with
-#    `pipx install ruff pytest mypy pre-commit`
-#
+# Dev tools (ruff, mypy, pytest, pre-commit) are managed by uv.
+# Run with: uv run ruff check, uv run mypy, uv run pytest
 [dependency-groups]
 dev = [
   "ruff>=0.11.12,<1.0.0",


### PR DESCRIPTION
## Context
Two commits that had been sitting unpushed on local `main` (predating the 2026-06-22 incident work), now moved onto a branch so they land through review instead of directly on `main`.

## Changes
- Replace pipx install advice with `uv run` instructions.
- Add a TODO to remove the global pipx installs of ruff and pytest (they shadow the project-local versions managed by uv and cause version drift).

Touches `TODO.md` and `pyproject.toml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ticket: none
